### PR TITLE
Fix body still showing in the scan

### DIFF
--- a/Patches/ShipTeleporterPatch.cs
+++ b/Patches/ShipTeleporterPatch.cs
@@ -15,6 +15,7 @@ namespace LCCollectYourDead.Patches {
 
                 if (scrapBody != null) {
                     RoundManager.Instance.CollectNewScrapForThisRound(scrapBody);
+                    scrapBody.isInShipRoom = true;
                 }
             }
         }


### PR DESCRIPTION
Thanks for creating this plugin!  I noticed the body still shows up when scanning for scraps after teleporting it.  I did some debugging and figured out that the scrapBody.isInShipRoom field remains false, so simply switching it to true fixes this issue.  Would you kindly please merge this into your branch and release a new build into the thunderstore?  Much appreciated!